### PR TITLE
feat: update CNINFO scraper with API changes and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,49 @@
     pdf2txt.py          爬虫所得PDF批量转txt
     main.py             统计keywords列表中每个关键字频数
     extract_text.js     指定PDF转txt
+    quick_start.py      快速下载指定公司年报
     keywords.txt        需要统计的关键字列表
     company_id.txt      需要爬取PDF的公司stock代码列表
 
+## Installation
+
+### Python Dependencies
+
+```bash
+pip install requests xlwt PyPDF2
+```
+
+### Node.js Dependencies
+
+```bash
+npm install pdf-text-extract
+```
+
 ## Usage
+
+### Quick Start - Download Single Company Reports
+
+```bash
+python quick_start.py <stock_code>
+```
+
+Example:
+
+```bash
+python quick_start.py 000888   # 峨眉山旅游
+```
+
+### Full Workflow
 
 First, set `keywords.txt` and `company_id.txt` if u need more keywords for statistic or more company to crawl on cninfo.
 
 ```
-python spider.py        # put PDF files in /pdf directory, modify spider.py as u need
+python spider.py        # put PDF files in /pdf directory
 python pdf2txt.py       # then covert all /pdf into /txt
 python main.py          # make statistics
 ```
+
+Output Excel files will be saved in `/xls` directory.
 
 ## Remark
 
@@ -45,25 +76,30 @@ Query format:
             (empty)                 # 搜索其他报文，如招股意向，此时配合searchkey检索
             category_ndbg_szsh      # 年报板块
 
-```
-# demo: 深交所年报，根据stock number下载年报
+**Important**: The API has been updated. Use `searchkey` parameter instead of `stock` parameter.
+
+```python
+# Updated query method (2026)
 def szseAnnual(page, stock):
     query_path = 'http://www.cninfo.com.cn/new/hisAnnouncement/query'
-    headers['User-Agent'] = random.choice(User_Agent)  # 定义User_Agent
-    query = {'pageNum': page,  # 页码
+    headers['User-Agent'] = random.choice(User_Agent)
+    query = {'pageNum': page,
              'pageSize': 30,
              'tabName': 'fulltext',
              'column': 'szse',  # 深交所
-             'stock': stock,
-             'searchkey': '',
+             'stock': '',       # ← Keep empty
+             'searchkey': stock,  # ← Use searchkey instead
              'secid': '',
              'plate': 'sz',
-             'category': 'category_ndbg_szsh;',  # 年度报告
+             'category': 'category_ndbg_szsh',  # 年度报告
              'trade': '',
-             'seDate': '2016-01-01+~+2019-4-26'  # 时间区间
+             'seDate': '2020-01-01~2026-02-15'  # Updated date range
              }
 
     namelist = requests.post(query_path, headers=headers, data=query)
-    return namelist.json()['announcements']
+    result = namelist.json()
+    if result and 'announcements' in result and result['announcements']:
+        return result['announcements']
+    return []
 
 ```

--- a/extract_image.py
+++ b/extract_image.py
@@ -2,7 +2,7 @@
 # PDF file image extractor
 ###
 import PyPDF2
-from PyPDF2.filters import *
+from PyPDF2.filters import *  # noqa: F403
 import copy
 import os
 import sys
@@ -62,9 +62,9 @@ def parseParam():
 def main():
     sourceName, outputFolder, targetPage = parseParam()
     fileBase = os.path.splitext(os.path.basename(sourceName))[0]
-    pdfObj = PyPDF2.PdfFileReader(open(sourceName, "rb"))
-    for iPage in range(0, pdfObj.numPages):
-        pageObj = pdfObj.getPage(iPage)
+    pdfObj = PyPDF2.PdfReader(open(sourceName, "rb"))
+    for iPage in range(0, len(pdfObj.pages)):
+        pageObj = pdfObj.pages[iPage]
 
         if targetPage and (iPage+1 != targetPage):
             continue
@@ -79,7 +79,7 @@ def main():
             if xObject[obj]['/Subtype'] == '/Image':
                 iImage += 1
                 title = obj[1:]
-                fileName = "{2}_p{0:0>3}_{3}".format(iPage+1, iImage, fileBase, title)
+                fileName = "{2}_p{0:0>3}_{1}".format(iPage + 1, title, fileBase)
                 outFileName = os.path.join(outputFolder, fileName)
 
                 size = (xObject[obj]['/Width'], xObject[obj]['/Height'])

--- a/extract_text.js
+++ b/extract_text.js
@@ -9,7 +9,9 @@ extract(input, function (err, pages) {
         console.dir(err)
         return
     }
-    fs.writeFile(output, pages, (error) => {
+    // pages is an array, join it into a string
+    var text = Array.isArray(pages) ? pages.join('\n') : pages
+    fs.writeFile(output, text, (error) => {
         if (error) {
             console.log(error);
         } else {

--- a/main.py
+++ b/main.py
@@ -64,8 +64,10 @@ def main(argv):
     for (k, v) in stat_all.items():
         valueE = 0
         valueN = 0
-        for i in range(0, SPLIT): valueE += v[keywords[i]]
-        for i in range(SPLIT, len(keywords)): valueN += v[keywords[i]]
+        for i in range(0, SPLIT):
+            valueE += v[keywords[i]]
+        for i in range(SPLIT, len(keywords)):
+            valueN += v[keywords[i]]
         stat_clf[k] = {'Efficiency': valueE, 'Novelty': valueN}
 
     utils.StatWriter('company_single_pdf.xls', keywords, stat_sig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "cninfo_process",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "pdf-text-extract": "^1.5.0"
+      }
+    },
+    "node_modules/pdf-text-extract": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pdf-text-extract/-/pdf-text-extract-1.5.0.tgz",
+      "integrity": "sha512-5zpNQljVf4h0b9sY8KGKDHxYoTYqDjahvkxmpHwpxBe3p92AWnscpWausl5/OaedOgnS8Pw53DOQx7bqtYcpow==",
+      "license": "BSD",
+      "dependencies": {
+        "yargs": "^1.2.5"
+      },
+      "bin": {
+        "pdf-text-extract": "bin/pdf-text-extract.js"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
+      "integrity": "sha512-7OGt4xXoWJQh5ulgZ78rKaqY7dNWbjfK+UKxGcIlaM2j7C4fqGchyv8CPvEWdRPrHp6Ula/YU8yGRpYGOHrI+g==",
+      "license": "MIT/X11"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "pdf-text-extract": "^1.5.0"
+  }
+}

--- a/pdf2txt.py
+++ b/pdf2txt.py
@@ -3,7 +3,6 @@
 #
 import os
 import sys
-import utils
 
 
 def main(argv):

--- a/quick_start.py
+++ b/quick_start.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+快速下载指定公司的年报
+使用方法: python3 quick_start.py <股票代码>
+例如: python3 quick_start.py 688777
+"""
+
+import os
+import sys
+
+from spider import Download, sseAnnual, szseAnnual, saving_path
+
+
+def download_annual_report(stock_code):
+    """下载指定股票的年报"""
+
+    print(f"\n{'=' * 60}")
+    print(f"开始下载 {stock_code} 的年度报告")
+    print(f"{'=' * 60}\n")
+
+    # 尝试沪市
+    print("1. 查询沪市（SSE）...")
+    announcements_sse = sseAnnual(1, stock_code)
+
+    # 尝试深市
+    print("2. 查询深市（SZSE）...")
+    announcements_szse = szseAnnual(1, stock_code)
+
+    all_announcements = []
+    if announcements_sse:
+        all_announcements.extend(announcements_sse)
+        print(f"   ✓ 找到 {len(announcements_sse)} 条沪市公告")
+    if announcements_szse:
+        all_announcements.extend(announcements_szse)
+        print(f"   ✓ 找到 {len(announcements_szse)} 条深市公告")
+
+    if not all_announcements:
+        print(f"\n✗ 未找到 {stock_code} 的任何公告")
+        print("  请确认股票代码是否正确")
+        return False
+
+    print(f"\n总共找到 {len(all_announcements)} 条公告")
+    print(f"\n{'=' * 60}")
+    print("开始下载PDF文件...")
+    print(f"{'=' * 60}\n")
+
+    # 下载PDF
+    Download(all_announcements)
+
+    print(f"\n{'=' * 60}")
+    print("✓ 下载完成！")
+    print(f"{'=' * 60}")
+    print(f"\nPDF文件保存在: {saving_path}")
+    print("\n下一步:")
+    print("  1. 转换PDF为文本: python3 pdf2txt.py")
+    print("  2. 统计关键词: python3 main.py")
+
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("使用方法: python3 quick_start.py <股票代码>")
+        print("\n示例:")
+        print("  python3 quick_start.py 000888  # 峨眉山旅游")
+        sys.exit(1)
+
+    stock_code = sys.argv[1]
+
+    # 创建必要的目录（使用脚本所在目录）
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    os.makedirs(os.path.join(script_dir, "pdf"), exist_ok=True)
+    os.makedirs(os.path.join(script_dir, "txt"), exist_ok=True)
+    os.makedirs(os.path.join(script_dir, "xls"), exist_ok=True)
+
+    download_annual_report(stock_code)

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,3 @@
-import collections
 import re
 import os
 import xlwt


### PR DESCRIPTION
## 概述
- 适配 CNINFO 最新 API 格式（使用 `searchkey` 参数替代已废弃的 `stock` 参数）
- 新增 `quick_start.py` 脚本，支持快速下载单个公司的年报
- 修复 PyPDF2 库兼容性问题（适配新版本 API）
- 更新支持的年报年份范围（2019-2025）

## 主要变更

### 新增功能
- **quick_start.py**: 一键下载指定公司年报
  ```bash
  python quick_start.py 000888  # 下载峨眉山旅游年报

Bug 修复

- 修复 PyPDF2 API 调用（PdfFileReader → PdfReader）
- 修复 extract_text.js 数组处理问题
- 更新 CNINFO API 查询格式

改进

- 增加下载进度反馈
- 改进错误处理（空返回值检查）
- 更新日期范围：2020-01-01 ~ 2026-02-15
- 下载 URL 升级为 HTTPS
- 清理未使用的导入

## 测试通过情况

- 使用 quick_start.py 下载测试公司年报